### PR TITLE
Change Behavior

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,8 @@ outputs:
     description: 'Total number of alerts'
   total_filtered_alerts:
     description: 'Total number of filtered alerts'
+  conclusion:
+    description: 'Conclusion of the action'
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,11 @@ inputs:
     required: false
     default: false
     type: boolean
+  print_summary:
+    description: 'Print a summary of the alerts'
+    required: false
+    default: false
+    type: boolean
   
 outputs:
   total_alerts:

--- a/dist/index.js
+++ b/dist/index.js
@@ -31843,6 +31843,7 @@ async function run() {
         const token = core.getInput("github_token");
         const owner = core.getInput("owner");
         const repo = core.getInput("repo");
+        const printSummary = core.getInput("print_summary") === "true";
         const doNotBreakPRCheck = core.getInput("do_not_break_pr_check") === "true";
         const maxAlerts = parseInt(core.getInput("max_alerts"), 10);
         const octokit = github.getOctokit(token);
@@ -32032,7 +32033,9 @@ ${summaryLines}${breakingMessage.length > 0 ? breakingMessage : ""}${nonBreaking
         // Set outputs for the action
         core.setOutput("total_filtered_alerts", alertCount);
         core.setOutput("total_alerts", alerts.length);
-        core.info(`summary: ${summary}`);
+        if (printSummary) {
+            core.info(`summary: ${summary}`);
+        }
         core.setOutput("conclusion", conclusion);
         if (conclusion == "success") {
             core.info("Code Scanning Alerts threshold not exceeded");

--- a/dist/index.js
+++ b/dist/index.js
@@ -32037,7 +32037,7 @@ ${summaryLines}${breakingMessage.length > 0 ? breakingMessage : ""}${nonBreaking
             core.info(`summary: ${summary}`);
         }
         core.setOutput("conclusion", conclusion);
-        if (conclusion == "success") {
+        if (conclusion == "success" || doNotBreakPRCheck) {
             core.info("Code Scanning Alerts threshold not exceeded");
         }
         else {

--- a/dist/index.js
+++ b/dist/index.js
@@ -31974,7 +31974,7 @@ ${summaryLines}${breakingMessage.length > 0 ? breakingMessage : ""}${nonBreaking
         // END: Define summary message
         let conclusion;
         conclusion = "success";
-        if (!doNotBreakPRCheck && alertCount > maxAlerts && maxAlerts >= 0) {
+        if (alertCount > maxAlerts && maxAlerts >= 0) {
             conclusion = "failure";
         }
         // Declares the final summary message

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ export async function run(): Promise<void> {
     const token: string = core.getInput("github_token");
     const owner: string = core.getInput("owner");
     const repo: string = core.getInput("repo");
+    const printSummary: boolean = core.getInput("print_summary") === "true";
 
     const doNotBreakPRCheck: boolean =
       core.getInput("do_not_break_pr_check") === "true";
@@ -244,7 +245,10 @@ ${summaryLines}${breakingMessage.length > 0 ? breakingMessage : ""}${nonBreaking
     core.setOutput("total_filtered_alerts", alertCount);
     core.setOutput("total_alerts", alerts.length);
 
-    core.info(`summary: ${summary}`);
+    if (printSummary) {
+      core.info(`summary: ${summary}`);
+    }
+    
     core.setOutput("conclusion", conclusion);
 
     if (conclusion == "success") {

--- a/src/run.ts
+++ b/src/run.ts
@@ -175,7 +175,7 @@ ${summaryLines}${breakingMessage.length > 0 ? breakingMessage : ""}${nonBreaking
 
     let conclusion: "failure" | "success";
     conclusion = "success";
-    if (!doNotBreakPRCheck && alertCount > maxAlerts && maxAlerts >= 0) {
+    if (alertCount > maxAlerts && maxAlerts >= 0) {
         conclusion = "failure";
     }
 
@@ -248,7 +248,7 @@ ${summaryLines}${breakingMessage.length > 0 ? breakingMessage : ""}${nonBreaking
     if (printSummary) {
       core.info(`summary: ${summary}`);
     }
-    
+
     core.setOutput("conclusion", conclusion);
 
     if (conclusion == "success") {

--- a/src/run.ts
+++ b/src/run.ts
@@ -248,10 +248,10 @@ ${summaryLines}${breakingMessage.length > 0 ? breakingMessage : ""}${nonBreaking
     if (printSummary) {
       core.info(`summary: ${summary}`);
     }
-
+    
     core.setOutput("conclusion", conclusion);
 
-    if (conclusion == "success") {
+    if (conclusion == "success" || doNotBreakPRCheck) {
       core.info("Code Scanning Alerts threshold not exceeded");
     } else {
       core.setFailed("Code scanning alerts exceed the allowed thresholds");


### PR DESCRIPTION
- Add new input print_summary (defaults to false) as a info on action run
- fix conclusion output which was not declared
- output conclusion sends success if doNotBreakPR is true, having a valid conclusion but without breaking the build
